### PR TITLE
Update docker images on new commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}        
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         
       - name: Build docker images
         working-directory: ./docker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,12 @@ jobs:
         id: tagging
         run: |
           if [ "${GITHUB_REF}" == "refs/heads/main" ]; then
-              echo "TAG=latest" >> $GITHUB_OUTPUT
+              VALUE="latest"
           else
-              echo "TAG=preview" >> $GITHUB_OUTPUT
+              VALUE="preview"
           fi
+          echo "::notice:: $VALUE"
+          echo "TAG=$VALUE" >> "$GITHUB_OUTPUT"
   
   build-and-test:
     name: Build and Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,9 @@ jobs:
   build-docker-image-services:
     name: Build docker image services
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: 
+      - versioning
+      - build-and-test
     
     env:
       TAG: ${{ needs.versioning.outputs.TAG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}        
+        
       - name: Build docker images
         working-directory: ./docker
         run: |


### PR DESCRIPTION
This pull request adds a step to the GitHub Actions workflow to log in to Docker Hub before building Docker images. This ensures that the workflow can authenticate with Docker Hub, which is necessary for pulling private images or pushing images to the registry.

Workflow improvements:

* Added a `Docker Login` step using the `docker/login-action@v3` action, with credentials sourced from repository secrets, before the image build process in `.github/workflows/build.yml`.